### PR TITLE
GPII-2401: Hooked up the GPII-app to the lifecycle manager events of login and logout start and completion

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "electron": "1.4.1",
     "request": "2.69.0",
     "infusion": "git://github.com/amb26/infusion.git#240c00be023732ac8dcc193a57bc1b46c58d2de7",
-    "gpii-windows": "git://github.com/gpii/windows.git#hst-2017",
+    "gpii-windows": "git://github.com/kaspermarkus/windows.git#5fc0d9c65db1ac9cff9495f87bc36907d4ecd499",
     "node-jqunit": "1.1.4"
   }
 }

--- a/src/html/message.html
+++ b/src/html/message.html
@@ -8,12 +8,14 @@
         <!-- TODO: Dynamically generate the message instead of hard coding it here -->
         <p>GPII</p>
         <p>One moment</p>
+        <p id="message">Placeholder</p>
         <script>
             const {remote} = require("electron");
-            document.write("<p> Key " +
-                remote.getGlobal("sharedObj").action + " " +
-                remote.getGlobal("sharedObj").name +
-                "</p>");
+            const {ipcRenderer} = require('electron');
+            // display whatever we get via the "updateMessage" IPC channel
+            ipcRenderer.on('updateMessage', (event, msg) => {
+                document.getElementById("message").textContent = msg;
+            });
         </script>
     </div>
 </body>


### PR DESCRIPTION
A bit of a hectic cleanup/commit - but things should be working.

I have:
* Hooked up to the new events (or rather model changes) of the flowmanager
* Centered window
* Ensured a minimum amount of display time of message
* used IPC instead of global variables when updating the message

I haven't done anything in terms of styling it as a speech bubble (or styling it in general)